### PR TITLE
Build docs automatically via GHA

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: Documentation
+
+on:
+  pull_request:
+
+  # Allow workflow to be run manually from the Actions tab:
+  workflow_dispatch:
+
+  # Run on main branch when a PR merges down to main
+  push:
+    tags: ['*']
+    branches:
+      - main
+
+jobs:
+  documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Build docs
+        working-directory: docs/
+        run: |
+          make html
+      - name: Deploy docs to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/
+          force_orphan: true


### PR DESCRIPTION
Add github action to automatically build documentation and push to repo's github pages (i.e., to make them publicly accessible).

Docs will be built to the `gh-pages` branch. Once repo is made public, github Pages can be enabled so that documentation will be publicly visible.

BLOCKER: Repo must be public in order for documentation to be available as a website!

https://github.com/ecophysviz-lab/DiveDB/settings/pages

